### PR TITLE
Added a Line Break after “Reading Log -“

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -143,7 +143,7 @@ internal class Program
 
         return new ReadingLogData
         {
-            Title = $"Reading Log - {postDate} (#{number})",
+            Title = $"Reading Log -{Environment.NewLine}{postDate} (#{number})",
             ReadingLogNumber = int.Parse(number ?? "0"),
         };
     }


### PR DESCRIPTION
Added a line break between “Reading Log -“ and the date to make it look nicer.

Closes #27